### PR TITLE
update!: modified Error() to use reflection only for reason type formatting

### DIFF
--- a/err.go
+++ b/err.go
@@ -82,7 +82,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
 )
 
@@ -105,9 +104,9 @@ import (
 // Go programs.
 type Err struct {
 	reason any
-	cause  error
 	file   string
 	line   int
+	cause  error
 }
 
 // Ok returns an instance of Err with no reason, indicating no error.
@@ -156,79 +155,39 @@ func (e Err) Line() int {
 // Error returns a string representation of the Err instance.
 // It formats the error, including the package path, reason, and cause.
 func (e Err) Error() string {
-	var buf strings.Builder
-
-	t := reflect.TypeOf(e)
-	s := t.PkgPath()
-	if len(s) > 0 {
-		buf.WriteString(s)
-		buf.WriteString(".")
+	if e.reason == nil { // Ok
+		return "github.com/sttk/errs.Err {}"
 	}
-	buf.WriteString(t.Name())
 
-	buf.WriteString(" { reason = ")
-
-	if e.reason == nil {
-		buf.WriteString("nil")
-	} else {
-		v := reflect.ValueOf(e.reason)
-
-		if v.Kind() == reflect.Ptr {
-			v = v.Elem()
+	v := reflect.ValueOf(e.reason)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	var reason string
+	if v.Kind() == reflect.Struct {
+		t := v.Type()
+		reason = t.PkgPath()
+		if len(reason) > 0 {
+			reason += "."
 		}
-
-		if v.Kind() != reflect.Struct {
-			if v.CanInterface() {
-				buf.WriteString(fmt.Sprintf("%v", v.Interface()))
-			}
-		} else {
-			t := v.Type()
-
-			s := t.PkgPath()
-			if len(s) > 0 {
-				buf.WriteString(s)
-				buf.WriteString(".")
-			}
-			buf.WriteString(t.Name())
-
-			n := v.NumField()
-
-			if n > 0 {
-				buf.WriteString(" { ")
-
-				for i := 0; i < n; i++ {
-					if i > 0 {
-						buf.WriteString(", ")
-					}
-
-					k := t.Field(i).Name
-
-					f := v.Field(i)
-					if f.CanInterface() { // false, if the field is not public
-						buf.WriteString(k)
-						buf.WriteString(": ")
-						buf.WriteString(fmt.Sprintf("%v", f.Interface()))
-					}
-				}
-
-				buf.WriteString(" }")
-			}
+		reason += t.Name()
+		flds := fmt.Sprintf("%+v", e.reason)
+		if strings.HasPrefix(flds, "&") {
+			flds = flds[1:]
 		}
+		if flds != "{}" {
+			reason += flds
+		}
+	} else if v.CanInterface() {
+		reason = fmt.Sprintf("%v", v.Interface())
 	}
 
-	buf.WriteString(", file = ")
-	buf.WriteString(e.file)
-	buf.WriteString(", line = ")
-	buf.WriteString(strconv.Itoa(e.line))
-
-	if e.cause != nil {
-		buf.WriteString(", cause = ")
-		buf.WriteString(e.cause.Error())
+	if e.cause == nil {
+		return fmt.Sprintf("github.com/sttk/errs.Err {reason:%s file:%s line:%d}",
+			reason, e.file, e.line)
 	}
-
-	buf.WriteString(" }")
-
-	return buf.String()
+	return fmt.Sprintf("github.com/sttk/errs.Err {reason:%s file:%s line:%d cause:%s}",
+		reason, e.file, e.line, e.cause)
 }
 
 // Unwrap returns the underlying cause of the error, allowing it to be chained.

--- a/err_test.go
+++ b/err_test.go
@@ -37,21 +37,21 @@ func TestErr(t *testing.T) {
 		t.Run("reason is a value", func(t *testing.T) {
 			err := errs.New(InvalidValue{Name: "foo", Value: "abc"})
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: foo, Value: abc }, file = err_test.go, line = 38 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:foo Value:abc} file:err_test.go line:38}")
 			assert.Nil(t, err.Cause())
 		})
 
 		t.Run("reason is a pointer", func(t *testing.T) {
 			err := errs.New(&InvalidValue{Name: "foo", Value: "abc"})
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: foo, Value: abc }, file = err_test.go, line = 45 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:foo Value:abc} file:err_test.go line:45}")
 			assert.Nil(t, err.Cause())
 		})
 
 		t.Run("reason is nil", func(t *testing.T) {
 			err := errs.New(nil)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = nil, file = err_test.go, line = 52 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {}")
 			assert.Nil(t, err.Cause())
 		})
 
@@ -59,7 +59,7 @@ func TestErr(t *testing.T) {
 			cause := errors.New("def")
 			err := errs.New(InvalidValue{Name: "foo", Value: "abc"}, cause)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: foo, Value: abc }, file = err_test.go, line = 60, cause = def }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:foo Value:abc} file:err_test.go line:60 cause:def}")
 			assert.Equal(t, err.Cause(), cause)
 		})
 
@@ -67,7 +67,7 @@ func TestErr(t *testing.T) {
 			cause := InvalidValueError{Name: "bar", Value: "def"}
 			err := errs.New(InvalidValue{Name: "foo", Value: "abc"}, cause)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: foo, Value: abc }, file = err_test.go, line = 68, cause = InvalidValue { Name: bar, Value: def } }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:foo Value:abc} file:err_test.go line:68 cause:InvalidValue { Name: bar, Value: def }}")
 			assert.Equal(t, err.Cause(), cause)
 		})
 
@@ -75,7 +75,7 @@ func TestErr(t *testing.T) {
 			cause := errs.New(FailToGetValue{Name: "foo"})
 			err := errs.New(InvalidValue{Name: "foo", Value: "abc"}, cause)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: foo, Value: abc }, file = err_test.go, line = 76, cause = github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToGetValue { Name: foo }, file = err_test.go, line = 75 } }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:foo Value:abc} file:err_test.go line:76 cause:github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToGetValue{Name:foo} file:err_test.go line:75}}")
 			assert.Equal(t, err.Cause(), cause)
 		})
 
@@ -83,7 +83,7 @@ func TestErr(t *testing.T) {
 			cause := errors.New("def")
 			err := errs.New(nil, cause)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = nil, file = err_test.go, line = 84, cause = def }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {}")
 			assert.Equal(t, err.Cause(), cause)
 		})
 
@@ -91,28 +91,28 @@ func TestErr(t *testing.T) {
 			var reason error = nil
 			err := errs.New(&reason)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = <nil>, file = err_test.go, line = 92 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:<nil> file:err_test.go line:92}")
 			assert.Nil(t, err.Cause())
 		})
 
 		t.Run("reason is a boolean", func(t *testing.T) {
 			err := errs.New(true)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = true, file = err_test.go, line = 99 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:true file:err_test.go line:99}")
 			assert.Nil(t, err.Cause())
 		})
 
 		t.Run("reason is a number", func(t *testing.T) {
 			err := errs.New(123)
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = 123, file = err_test.go, line = 106 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:123 file:err_test.go line:106}")
 			assert.Nil(t, err.Cause())
 		})
 
 		t.Run("reason is a string", func(t *testing.T) {
 			err := errs.New("abc")
 
-			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = abc, file = err_test.go, line = 113 }")
+			assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {reason:abc file:err_test.go line:113}")
 			assert.Nil(t, err.Cause())
 		})
 	})
@@ -120,7 +120,7 @@ func TestErr(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
 		err := errs.Ok()
 
-		assert.Equal(t, err.Error(), "github.com/sttk/errs.Err { reason = nil, file = , line = 0 }")
+		assert.Equal(t, err.Error(), "github.com/sttk/errs.Err {}")
 		assert.Nil(t, err.Cause())
 	})
 
@@ -491,12 +491,12 @@ func TestErr(t *testing.T) {
 	t.Run("Print", func(t *testing.T) {
 		t.Run("%v", func(t *testing.T) {
 			err := errs.New(InvalidValue{Name: "abc", Value: "def"})
-			assert.Equal(t, fmt.Sprintf("%v", err), `github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: abc, Value: def }, file = err_test.go, line = 493 }`)
+			assert.Equal(t, fmt.Sprintf("%v", err), `github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:abc Value:def} file:err_test.go line:493}`)
 		})
 
 		t.Run("%w", func(t *testing.T) {
 			err := errs.New(InvalidValue{Name: "abc", Value: "def"})
-			assert.Equal(t, fmt.Errorf("%w", err).Error(), `github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.InvalidValue { Name: abc, Value: def }, file = err_test.go, line = 498 }`)
+			assert.Equal(t, fmt.Errorf("%w", err).Error(), `github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.InvalidValue{Name:abc Value:def} file:err_test.go line:498}`)
 		})
 	})
 }

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -40,10 +40,10 @@ func ExampleNew() {
 	}, cause)
 	fmt.Printf("(4) %v\n", err)
 	// Output:
-	// (1) github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToDoSomething, file = example_err_test.go, line = 20 }
-	// (2) github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToDoWithParams { Param1: ABC, Param2: 123 }, file = example_err_test.go, line = 24 }
-	// (3) github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToDoSomething, file = example_err_test.go, line = 33, cause = Causal error }
-	// (4) github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToDoWithParams { Param1: ABC, Param2: 123 }, file = example_err_test.go, line = 37, cause = Causal error }
+	// (1) github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToDoSomething file:example_err_test.go line:20}
+	// (2) github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToDoWithParams{Param1:ABC Param2:123} file:example_err_test.go line:24}
+	// (3) github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToDoSomething file:example_err_test.go line:33 cause:Causal error}
+	// (4) github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToDoWithParams{Param1:ABC Param2:123} file:example_err_test.go line:37 cause:Causal error}
 }
 
 func ExampleOk() {
@@ -51,7 +51,7 @@ func ExampleOk() {
 	fmt.Printf("err = %v\n", err)
 	fmt.Printf("err.IsOk() = %v\n", err.IsOk())
 	// Output:
-	// err = github.com/sttk/errs.Err { reason = nil, file = , line = 0 }
+	// err = github.com/sttk/errs.Err {}
 	// err.IsOk() = true
 }
 
@@ -80,7 +80,7 @@ func ExampleErr_Error() {
 	}, cause)
 	fmt.Printf("%v\n", err.Error())
 	// Output:
-	// github.com/sttk/errs.Err { reason = github.com/sttk/errs_test.FailToDoSomething { Param1: ABC, Param2: 123 }, file = example_err_test.go, line = 77, cause = Causal error }
+	// github.com/sttk/errs.Err {reason:github.com/sttk/errs_test.FailToDoSomething{Param1:ABC Param2:123} file:example_err_test.go line:77 cause:Causal error}
 }
 
 func ExampleErr_IsOk() {

--- a/notify_test.go
+++ b/notify_test.go
@@ -172,9 +172,9 @@ func TestNotifyErr(t *testing.T) {
 
 		assert.Equal(t, syncLogs.Len(), 2)
 		log := syncLogs.Front()
-		assert.Contains(t, log.Value, "github.com/sttk/errs.Err { reason = github.com/sttk/errs.FailToDoSomething, file = notify_test.go, line = 171 }-1:")
+		assert.Contains(t, log.Value, "github.com/sttk/errs.Err {reason:github.com/sttk/errs.FailToDoSomething file:notify_test.go line:171}-1:")
 		log = log.Next()
-		assert.Contains(t, log.Value, "github.com/sttk/errs.Err { reason = github.com/sttk/errs.FailToDoSomething, file = notify_test.go, line = 171 }-2:")
+		assert.Contains(t, log.Value, "github.com/sttk/errs.Err {reason:github.com/sttk/errs.FailToDoSomething file:notify_test.go line:171}-2:")
 		log = log.Next()
 		assert.Nil(t, log)
 
@@ -182,9 +182,9 @@ func TestNotifyErr(t *testing.T) {
 
 		assert.Equal(t, asyncLogs.Len(), 2)
 		log = asyncLogs.Front()
-		assert.Contains(t, log.Value, "github.com/sttk/errs.Err { reason = github.com/sttk/errs.FailToDoSomething, file = notify_test.go, line = 171 }-4:")
+		assert.Contains(t, log.Value, "github.com/sttk/errs.Err {reason:github.com/sttk/errs.FailToDoSomething file:notify_test.go line:171}-4:")
 		log = log.Next()
-		assert.Contains(t, log.Value, "github.com/sttk/errs.Err { reason = github.com/sttk/errs.FailToDoSomething, file = notify_test.go, line = 171 }-3:")
+		assert.Contains(t, log.Value, "github.com/sttk/errs.Err {reason:github.com/sttk/errs.FailToDoSomething file:notify_test.go line:171}-3:")
 		log = log.Next()
 		assert.Nil(t, log)
 	})


### PR DESCRIPTION
This PR changes the format of `errs.Err#Error()` output.

- The output of `errs.Ok()` is changed to `github.com/sttk/errs.Err {}`
- Spaces and commas between fields and values have been removed from the output of a reason with fields, and the equals sign has been changed to a colon.