### PR TITLE
cicd: reduced the Go 1.2x versions used by CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gover: ['~1.18', '~1.19', '~1.20', '~1.21', '~1.22', '~1.23', '~1.24', '~1.25', '~1.26']
+        gover: ['~1.18', '~1.19', '~1.26']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Because of skipping `dyld[53818]: missing LC_UUID load command` error occurs on macosx on go 1.21 and go 1.22.